### PR TITLE
Index patch2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ db.sqlite3-journal
 instance/
 .webassets-cache
 
+# MacOS
+.DS_Store
+
 # Scrapy stuff:
 .scrapy
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Contributions are welcome! If you would like to contribute to this project, plea
 - Fork the repository and create your branch.
 - Make your changes and ensure the code follows the project's coding style.
 - Test your changes thoroughly.
+- Run:
+
+        pre-commit install
+
+  to install the pre-commit hooks locally.
+- Commit your changes.
 - Submit a pull request with a clear description of your changes.
 
 ## License & Code of Conduct

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,12 +34,12 @@
                                 density plots</a></li>
                     </ul>
                     <ul>
-                        <li><a href="                    04-visualize-multiple-distribution-histograms.html">Multiple
+                        <li><a href="04-visualize-multiple-distribution-histograms.html">Multiple
                                 distribution histogram and
                                 density plots</a></li>
                     </ul>
                     <ul>
-                        <li><a href="                    05-visualize-distributions-boxplots.html">Visualizing many distributions at once</a></li>
+                        <li><a href="05-visualize-distributions-boxplots.html">Visualizing many distributions at once</a></li>
                     </ul>
 
                 </li>


### PR DESCRIPTION
I noticed that the `index.html` file was still showing a 404 error on the GH pages even though it worked locally. This was due to the file name being different from the actual .html link. I have corrected that now.

**Tasks**
- [x] Modified the file title for the 6th notebook and HTML files.
- [x] Modified `README.md` to add instructions for installing pre-commit hooks. 